### PR TITLE
Cls scores correction

### DIFF
--- a/yolo_v3.py
+++ b/yolo_v3.py
@@ -329,6 +329,7 @@ def _iou(box1, box2):
     """
     Computes Intersection over Union value for 2 bounding boxes
 
+
     :param box1: array of 4 values (top left and bottom right coords): [x0, y0, x1, x2]
     :param box2: same as box1
     :return: IoU

--- a/yolo_v3.py
+++ b/yolo_v3.py
@@ -390,6 +390,7 @@ def non_max_suppression(predictions_with_boxes, confidence_threshold, iou_thresh
                     result[cls] = []
                 result[cls].append((box, score))
                 cls_boxes = cls_boxes[1:]
+		cls_scores = cls_scores[1:]
                 ious = np.array([_iou(box, x) for x in cls_boxes])
                 iou_mask = ious < iou_threshold
                 cls_boxes = cls_boxes[np.nonzero(iou_mask)]

--- a/yolo_v3.py
+++ b/yolo_v3.py
@@ -328,7 +328,7 @@ def detections_boxes(detections):
 def _iou(box1, box2):
     """
     Computes Intersection over Union value for 2 bounding boxes
-    
+
     :param box1: array of 4 values (top left and bottom right coords): [x0, y0, x1, x2]
     :param box2: same as box1
     :return: IoU
@@ -390,7 +390,7 @@ def non_max_suppression(predictions_with_boxes, confidence_threshold, iou_thresh
                     result[cls] = []
                 result[cls].append((box, score))
                 cls_boxes = cls_boxes[1:]
-		        cls_scores = cls_scores[1:]
+                cls_scores=cls_scores[1:]
                 ious = np.array([_iou(box, x) for x in cls_boxes])
                 iou_mask = ious < iou_threshold
                 cls_boxes = cls_boxes[np.nonzero(iou_mask)]

--- a/yolo_v3.py
+++ b/yolo_v3.py
@@ -329,7 +329,6 @@ def _iou(box1, box2):
     """
     Computes Intersection over Union value for 2 bounding boxes
 
-
     :param box1: array of 4 values (top left and bottom right coords): [x0, y0, x1, x2]
     :param box2: same as box1
     :return: IoU

--- a/yolo_v3.py
+++ b/yolo_v3.py
@@ -390,7 +390,7 @@ def non_max_suppression(predictions_with_boxes, confidence_threshold, iou_thresh
                     result[cls] = []
                 result[cls].append((box, score))
                 cls_boxes = cls_boxes[1:]
-		cls_scores = cls_scores[1:]
+		        cls_scores = cls_scores[1:]
                 ious = np.array([_iou(box, x) for x in cls_boxes])
                 iou_mask = ious < iou_threshold
                 cls_boxes = cls_boxes[np.nonzero(iou_mask)]


### PR DESCRIPTION
The cls_scores first row is discarded too, in order to match the cls_boxes array.
In that way, one does not obtain the same score for all the objects belonging to the same class