### PR TITLE
Convert weights to tensorflow protobuf file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,41 @@
-# tensorflow-yolo-v3
+# tensorflow-yolo-v3 (fork)
 
-Implementation of YOLO v3 object detector in Tensorflow (TF-Slim). Full tutorial can be found [here](https://medium.com/@pawekapica_31302/implementing-yolo-v3-in-tensorflow-tf-slim-c3c55ff59dbe).
+[Original repo](https://github.com/mystic123/tensorflow-yolo-v3)
 
-Tested on Python 3.5, Tensorflow 1.11.0 on Ubuntu 16.04.
-
-## Todo list:
-- [x] YOLO v3 architecture
-- [x] Basic working demo
-- [x] Weights converter (util for exporting loaded COCO weights as TF checkpoint)
-- [ ] Training pipeline
-- [ ] More backends
+Converts the yolov3 weights to a full protobuf graph, enabling its use in other apis (e.g. the tensorflow C api).
 
 ## How to run the demo:
 To run demo type this in the command line:
 
 1. Download COCO class names file: `wget https://raw.githubusercontent.com/pjreddie/darknet/master/data/coco.names`
 2. Download and convert model weights:    
-    1. Download binary file with weights from https://pjreddie.com/darknet/yolo/
-    2. Run `python ./convert_weights.py`
+    1. Download binary file with desired weights: 
+        1. Full weights: `wget https://pjreddie.com/media/files/yolov3.weights`
+        1. Tiny weights: `wget https://pjreddie.com/media/files/yolov3-tiny.weights` 
+    2. Run `python ./convert_weights_pb.py        
 3. Run `python ./demo.py --input_img <path-to-image> --output_img <name-of-output-image>`
 
-## Changelog:
-#### 2018-10-29: 
-- Added weights converter from Darknet format to Tensorflow model checkpoint
-- Updated demo.py script to use TF saved checkpoint
-- Moved utility functions (load_weights, load_coco_names etc.) to utils.py
-- Added data_format flag, possible options are: NCHW (works only on GPU) / NHWC (woks on both CPU and GPU)
-- Merged PR36, which fixes the bug with bad stride in convolutional layer in YOLOv3-Tiny. Thank you @LucasMahieu.
-#### Pre 2018-10-29: 
-- Merged PR with YOLOv3-Tiny model
-- Bug fixes
+
+####Optional Flags
+1. convert_weights_pb.py:
+    1. `--tiny`
+        1. Use yolov3-tiny
+    2. `--weights_file`
+        1. Path to the desired weights file
+    3. `--class_names`
+        1. Path to the class names file
+    4. `--output_graph`
+        1. Location to write the output .pb graph to
+    5. `--data_format`
+        1.  `NCHW` (gpu only) or `NHWC`
+2. demo.py
+    1. `--frozen_model`
+        1. Path to the desired frozen model
+    2. `--class_names`
+        1. Path to the class names file
+    3. `--conf_threshold`
+        1. Desired confidence threshold
+    4. `--iou_threshold`
+        1. Desired iou threshold
+    5. `--gpu_memory_fraction`
+        1. Fraction of gpu memory to work with

--- a/README.md
+++ b/README.md
@@ -1,8 +1,19 @@
 # tensorflow-yolo-v3 (fork)
 
+Converts the yolov3 weights to a full protobuf graph, enabling its use in other apis (e.g. the tensorflow C api).
+
 [Original repo](https://github.com/mystic123/tensorflow-yolo-v3)
 
-Converts the yolov3 weights to a full protobuf graph, enabling its use in other apis (e.g. the tensorflow C api).
+Implementation of YOLO v3 object detector in Tensorflow (TF-Slim). Full tutorial can be found [here](https://medium.com/@pawekapica_31302/implementing-yolo-v3-in-tensorflow-tf-slim-c3c55ff59dbe).
+
+Tested on Python 3.5, Tensorflow 1.11.0 on Ubuntu 16.04.
+
+## Todo list:
+- [x] YOLO v3 architecture
+- [x] Basic working demo
+- [x] Weights converter (util for exporting loaded COCO weights as TF checkpoint)
+- [ ] Training pipeline
+- [ ] More backends
 
 ## How to run the demo:
 To run demo type this in the command line:
@@ -12,30 +23,47 @@ To run demo type this in the command line:
     1. Download binary file with desired weights: 
         1. Full weights: `wget https://pjreddie.com/media/files/yolov3.weights`
         1. Tiny weights: `wget https://pjreddie.com/media/files/yolov3-tiny.weights` 
-    2. Run `python ./convert_weights_pb.py        
-3. Run `python ./demo.py --input_img <path-to-image> --output_img <name-of-output-image>`
+    2. Run `python ./convert_weights.py` and `python ./convert_weights_pb.py`        
+3. Run `python ./demo.py --input_img <path-to-image> --output_img <name-of-output-image> --frozen_model <path-to-frozen-model>`
 
 
 ####Optional Flags
-1. convert_weights_pb.py:
-    1. `--tiny`
-        1. Use yolov3-tiny
+1. convert_weights:
+    1. `--class_names`
+        1. Path to the class names file
     2. `--weights_file`
         1. Path to the desired weights file
-    3. `--class_names`
-        1. Path to the class names file
-    4. `--output_graph`
-        1. Location to write the output .pb graph to
-    5. `--data_format`
+    3. `--data_format`
         1.  `NCHW` (gpu only) or `NHWC`
-2. demo.py
-    1. `--frozen_model`
-        1. Path to the desired frozen model
-    2. `--class_names`
+    4. `--tiny`
+        1. Use yolov3-tiny
+    5. `--ckpt_file`
+        1. Output checkpoint file
+2. convert_weights_pb.py:
+    1. `--class_names`
+            1. Path to the class names file
+    2. `--weights_file`
+        1. Path to the desired weights file    
+    3. `--data_format`
+        1.  `NCHW` (gpu only) or `NHWC`
+    4. `--tiny`
+        1. Use yolov3-tiny
+    5. `--output_graph`
+        1. Location to write the output .pb graph to
+3. demo.py
+    1. `--class_names`
         1. Path to the class names file
-    3. `--conf_threshold`
+    2. `--weights_file`
+        1. Path to the desired weights file
+    3. `--data_format`
+        1.  `NCHW` (gpu only) or `NHWC`
+    4. `--ckpt_file`
+        1. Path to the checkpoint file
+    5. `--frozen_model`
+        1. Path to the frozen model
+    6. `--conf_threshold`
         1. Desired confidence threshold
-    4. `--iou_threshold`
+    7. `--iou_threshold`
         1. Desired iou threshold
-    5. `--gpu_memory_fraction`
+    8. `--gpu_memory_fraction`
         1. Fraction of gpu memory to work with

--- a/README.md
+++ b/README.md
@@ -1,8 +1,4 @@
-# tensorflow-yolo-v3 (fork)
-
-Converts the yolov3 weights to a full protobuf graph, enabling its use in other apis (e.g. the tensorflow C api).
-
-[Original repo](https://github.com/mystic123/tensorflow-yolo-v3)
+# tensorflow-yolo-v3
 
 Implementation of YOLO v3 object detector in Tensorflow (TF-Slim). Full tutorial can be found [here](https://medium.com/@pawekapica_31302/implementing-yolo-v3-in-tensorflow-tf-slim-c3c55ff59dbe).
 

--- a/convert_weights_pb.py
+++ b/convert_weights_pb.py
@@ -20,7 +20,7 @@ tf.app.flags.DEFINE_string(
     'output_graph', 'frozen_darknet_yolov3_model.pb', 'Frozen tensorflow protobuf model output path')
 
 tf.app.flags.DEFINE_bool(
-    'tiny', True, 'Use tiny version of YOLOv3')
+    'tiny', False, 'Use tiny version of YOLOv3')
 tf.app.flags.DEFINE_integer(
     'size', 416, 'Image size')
 
@@ -46,7 +46,7 @@ def main(argv=None):
 
     with tf.Session() as sess:
         sess.run(load_ops)
-        freeze_graph(sess)
+        freeze_graph(sess, FLAGS.output_graph)
 
 if __name__ == '__main__':
     tf.app.run()

--- a/convert_weights_pb.py
+++ b/convert_weights_pb.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+
+import numpy as np
+import tensorflow as tf
+import yolo_v3
+import yolo_v3_tiny
+from PIL import Image, ImageDraw
+
+from utils import load_weights, load_coco_names, detections_boxes
+
+FLAGS = tf.app.flags.FLAGS
+
+tf.app.flags.DEFINE_string('class_names', 'coco.names', 'File with class names')
+tf.app.flags.DEFINE_string('weights_file', 'yolov3.weights', 'Binary file with detector weights')
+tf.app.flags.DEFINE_string('output_graph', 'frozen_darknet_yolov3_model.pb', 'Frozen tensorflow protobuf model output path')
+tf.app.flags.DEFINE_string('data_format', 'NCHW', 'Data format: NCHW (gpu only) / NHWC')
+tf.app.flags.DEFINE_integer('size', 416, 'Image size')
+tf.app.flags.DEFINE_bool('tiny', True, 'Use tiny version of YOLOv3')
+
+
+def freeze_graph(sess):
+
+    output_node_names = [
+        "output_boxes",
+        "inputs",
+    ]
+    output_node_names = ",".join(output_node_names)
+
+    output_graph_def = tf.graph_util.convert_variables_to_constants(
+        sess,  # The session is used to retrieve the weights
+        tf.get_default_graph().as_graph_def(),  # The graph_def is used to retrieve the nodes
+        output_node_names.split(",")  # The output node names are used to select the useful nodes
+    )
+
+    # Finally we serialize and dump the output graph to the filesystem
+    with tf.gfile.GFile(FLAGS.output_graph, "wb") as f:
+        f.write(output_graph_def.SerializeToString())
+    print("%d ops in the final graph." % len(output_graph_def.node))
+
+def main(argv=None):
+    if FLAGS.tiny:
+        model = yolo_v3_tiny.yolo_v3_tiny
+    else:
+        model = yolo_v3.yolo_v3
+
+    classes = load_coco_names(FLAGS.class_names)
+
+    # placeholder for detector inputs
+    inputs = tf.placeholder(tf.float32, [None, FLAGS.size, FLAGS.size, 3], "inputs")
+
+    with tf.variable_scope('detector'):
+        detections = model(inputs, len(classes), data_format=FLAGS.data_format)
+        load_ops = load_weights(tf.global_variables(scope='detector'), FLAGS.weights_file)
+
+    # Sets the output nodes in the current session
+    boxes = detections_boxes(detections)
+
+    with tf.Session() as sess:
+        sess.run(load_ops)
+        freeze_graph(sess)
+
+if __name__ == '__main__':
+    tf.app.run()

--- a/convert_weights_pb.py
+++ b/convert_weights_pb.py
@@ -6,36 +6,25 @@ import yolo_v3
 import yolo_v3_tiny
 from PIL import Image, ImageDraw
 
-from utils import load_weights, load_coco_names, detections_boxes
+from utils import load_weights, load_coco_names, detections_boxes, freeze_graph
 
 FLAGS = tf.app.flags.FLAGS
 
-tf.app.flags.DEFINE_string('class_names', 'coco.names', 'File with class names')
-tf.app.flags.DEFINE_string('weights_file', 'yolov3.weights', 'Binary file with detector weights')
-tf.app.flags.DEFINE_string('output_graph', 'frozen_darknet_yolov3_model.pb', 'Frozen tensorflow protobuf model output path')
-tf.app.flags.DEFINE_string('data_format', 'NCHW', 'Data format: NCHW (gpu only) / NHWC')
-tf.app.flags.DEFINE_integer('size', 416, 'Image size')
-tf.app.flags.DEFINE_bool('tiny', True, 'Use tiny version of YOLOv3')
+tf.app.flags.DEFINE_string(
+    'class_names', 'coco.names', 'File with class names')
+tf.app.flags.DEFINE_string(
+    'weights_file', 'yolov3.weights', 'Binary file with detector weights')
+tf.app.flags.DEFINE_string(
+    'data_format', 'NCHW', 'Data format: NCHW (gpu only) / NHWC')
+tf.app.flags.DEFINE_string(
+    'output_graph', 'frozen_darknet_yolov3_model.pb', 'Frozen tensorflow protobuf model output path')
+
+tf.app.flags.DEFINE_bool(
+    'tiny', True, 'Use tiny version of YOLOv3')
+tf.app.flags.DEFINE_integer(
+    'size', 416, 'Image size')
 
 
-def freeze_graph(sess):
-
-    output_node_names = [
-        "output_boxes",
-        "inputs",
-    ]
-    output_node_names = ",".join(output_node_names)
-
-    output_graph_def = tf.graph_util.convert_variables_to_constants(
-        sess,  # The session is used to retrieve the weights
-        tf.get_default_graph().as_graph_def(),  # The graph_def is used to retrieve the nodes
-        output_node_names.split(",")  # The output node names are used to select the useful nodes
-    )
-
-    # Finally we serialize and dump the output graph to the filesystem
-    with tf.gfile.GFile(FLAGS.output_graph, "wb") as f:
-        f.write(output_graph_def.SerializeToString())
-    print("%d ops in the final graph." % len(output_graph_def.node))
 
 def main(argv=None):
     if FLAGS.tiny:

--- a/demo.py
+++ b/demo.py
@@ -3,70 +3,101 @@
 import numpy as np
 import tensorflow as tf
 from PIL import Image
-
 import time
 
-from utils import load_coco_names, draw_boxes, detections_boxes, non_max_suppression
+import yolo_v3
+import yolo_v3_tiny
+
+from utils import load_coco_names, draw_boxes, detections_boxes, non_max_suppression, load_graph
 
 FLAGS = tf.app.flags.FLAGS
 
-tf.app.flags.DEFINE_string('input_img', '', 'Input image')
-tf.app.flags.DEFINE_string('output_img', '', 'Output image')
-tf.app.flags.DEFINE_string('class_names', 'coco.names', 'File with class names')
-tf.app.flags.DEFINE_string('frozen_model', 'frozen_darknet_yolov3_model.pb', 'Frozen tensorflow protobuf model')
+tf.app.flags.DEFINE_string(
+    'input_img', '', 'Input image')
+tf.app.flags.DEFINE_string(
+    'output_img', '', 'Output image')
+tf.app.flags.DEFINE_string(
+    'class_names', 'coco.names', 'File with class names')
+tf.app.flags.DEFINE_string(
+    'weights_file', 'yolov3.weights', 'Binary file with detector weights')
+tf.app.flags.DEFINE_string(
+    'data_format', 'NCHW', 'Data format: NCHW (gpu only) / NHWC')
+tf.app.flags.DEFINE_string(
+    'ckpt_file', './saved_model/model.ckpt', 'Checkpoint file')
+tf.app.flags.DEFINE_string(
+    'frozen_model', '', 'Frozen tensorflow protobuf model')
+tf.app.flags.DEFINE_bool(
+    'tiny', False, 'Use tiny version of YOLOv3')
 
-tf.app.flags.DEFINE_integer('size', 416, 'Image size')
+tf.app.flags.DEFINE_integer(
+    'size', 416, 'Image size')
 
-tf.app.flags.DEFINE_float('conf_threshold', 0.5, 'Confidence threshold')
-tf.app.flags.DEFINE_float('iou_threshold', 0.4, 'IoU threshold')
+tf.app.flags.DEFINE_float(
+    'conf_threshold', 0.5, 'Confidence threshold')
+tf.app.flags.DEFINE_float(
+    'iou_threshold', 0.4, 'IoU threshold')
 
-tf.app.flags.DEFINE_float('gpu_memory_fraction', 0.8, 'Gpu memory fraction to use')
-
-
-
-def load_graph(frozen_graph_filename):
-    # We load the protobuf file from the disk and parse it to retrieve the
-    # unserialized graph_def
-    with tf.gfile.GFile(frozen_graph_filename, "rb") as f:
-        graph_def = tf.GraphDef()
-        graph_def.ParseFromString(f.read())
-
-    # Then, we import the graph_def into a new Graph and returns it
-    with tf.Graph().as_default() as graph:
-        # The name var will prefix every op/nodes in your graph
-        # Since we load everything in a new graph, this is not needed
-        tf.import_graph_def(graph_def, name="")
-    return graph
+tf.app.flags.DEFINE_float(
+    'gpu_memory_fraction', 0.8, 'Gpu memory fraction to use')
 
 
 def main(argv=None):
 
-    print("Loading frozen graph")
-    t0 = time.time()
-    frozenGraph = load_graph(FLAGS.frozen_model)
-    print("Loaded graph in {:.2f}s".format(time.time()-t0))
+    gpu_options = tf.GPUOptions(per_process_gpu_memory_fraction=FLAGS.gpu_memory_fraction)
 
     img = Image.open(FLAGS.input_img)
     img_resized = img.resize(size=(FLAGS.size, FLAGS.size))
 
     classes = load_coco_names(FLAGS.class_names)
 
-    with frozenGraph.as_default():
-        boxes = tf.get_default_graph().get_tensor_by_name("output_boxes:0")
-        inputs = tf.get_default_graph().get_tensor_by_name("inputs:0")
+    if FLAGS.frozen_model:
 
-    gpu_options = tf.GPUOptions(per_process_gpu_memory_fraction=FLAGS.gpu_memory_fraction)
-    tfSession = tf.Session(
-        graph=frozenGraph,
-        config=tf.ConfigProto(
-            gpu_options=gpu_options,
-            log_device_placement=False,
+        t0 = time.time()
+        frozenGraph = load_graph(FLAGS.frozen_model)
+        print("Loaded graph in {:.2f}s".format(time.time()-t0))
+
+        with frozenGraph.as_default():
+            boxes = tf.get_default_graph().get_tensor_by_name("output_boxes:0")
+            inputs = tf.get_default_graph().get_tensor_by_name("inputs:0")
+
+        tf_session = tf.Session(
+            graph=frozenGraph,
+            config=tf.ConfigProto(
+                gpu_options=gpu_options,
+                log_device_placement=False,
+            )
         )
-    )
+
+    else:
+        if FLAGS.tiny:
+            model = yolo_v3_tiny.yolo_v3_tiny
+        else:
+            model = yolo_v3.yolo_v3
+
+        # placeholder for detector inputs
+        inputs = tf.placeholder(tf.float32, [1, FLAGS.size, FLAGS.size, 3])
+
+        with tf.variable_scope('detector'):
+            detections = model(inputs, len(classes),
+                               data_format=FLAGS.data_format)
+
+        saver = tf.train.Saver(var_list=tf.global_variables(scope='detector'))
+
+        boxes = detections_boxes(detections)
+
+        tf_session = tf.Session(
+            config=tf.ConfigProto(
+                gpu_options=gpu_options,
+                log_device_placement=False,
+            )
+        )
+
+        saver.restore(tf_session, FLAGS.ckpt_file)
+        print('Model restored.')
 
     t0 = time.time()
 
-    detected_boxes = tfSession.run(boxes, feed_dict={inputs: [np.array(img_resized, dtype=np.float32)]})
+    detected_boxes = tf_session.run(boxes, feed_dict={inputs: [np.array(img_resized, dtype=np.float32)]})
 
     filtered_boxes = non_max_suppression(detected_boxes,
                                          confidence_threshold=FLAGS.conf_threshold,
@@ -77,6 +108,7 @@ def main(argv=None):
 
     img.save(FLAGS.output_img)
 
+    tf_session.close()
 
 if __name__ == '__main__':
     tf.app.run()

--- a/demo.py
+++ b/demo.py
@@ -8,7 +8,7 @@ import time
 import yolo_v3
 import yolo_v3_tiny
 
-from utils import load_coco_names, draw_boxes, get_boxes_and_inputs, non_max_suppression, load_graph
+from utils import load_coco_names, draw_boxes, get_boxes_and_inputs, get_boxes_and_inputs_pb, non_max_suppression, load_graph
 
 FLAGS = tf.app.flags.FLAGS
 
@@ -60,7 +60,7 @@ def main(argv=None):
         frozenGraph = load_graph(FLAGS.frozen_model)
         print("Loaded graph in {:.2f}s".format(time.time()-t0))
 
-        boxes, inputs = get_boxes_and_inputs(frozenGraph)
+        boxes, inputs = get_boxes_and_inputs_pb(frozenGraph)
 
         with tf.Session(graph=frozenGraph, config=config) as sess:
             t0 = time.time()

--- a/demo.py
+++ b/demo.py
@@ -2,68 +2,76 @@
 
 import numpy as np
 import tensorflow as tf
-from PIL import Image, ImageDraw
+from PIL import Image
 
-import yolo_v3
-import yolo_v3_tiny
+import time
 
-from utils import load_coco_names, draw_boxes, convert_to_original_size, \
-    load_weights, detections_boxes, non_max_suppression
+from utils import load_coco_names, draw_boxes, detections_boxes, non_max_suppression
 
 FLAGS = tf.app.flags.FLAGS
 
 tf.app.flags.DEFINE_string('input_img', '', 'Input image')
 tf.app.flags.DEFINE_string('output_img', '', 'Output image')
 
-tf.app.flags.DEFINE_string(
-    'class_names', 'coco.names', 'File with class names')
-tf.app.flags.DEFINE_string(
-    'weights_file', 'yolov3.weights', 'Binary file with detector weights')
-tf.app.flags.DEFINE_string(
-    'data_format', 'NCHW', 'Data format: NCHW (gpu only) / NHWC')
-tf.app.flags.DEFINE_string(
-    'ckpt_file', './saved_model/model.ckpt', 'Checkpoint file')
-tf.app.flags.DEFINE_bool(
-    'tiny', False, 'Use tiny version of YOLOv3')
+tf.app.flags.DEFINE_string('frozen_model', 'frozen_darknet_yolov3_model.pb', 'Frozen tensorflow protobuf model')
 
 tf.app.flags.DEFINE_integer('size', 416, 'Image size')
 
 tf.app.flags.DEFINE_float('conf_threshold', 0.5, 'Confidence threshold')
 tf.app.flags.DEFINE_float('iou_threshold', 0.4, 'IoU threshold')
 
+tf.app.flags.DEFINE_float('gpu_memory_fraction', 0.8, 'Gpu memory fraction to use')
+
+
+
+def load_graph(frozen_graph_filename):
+    # We load the protobuf file from the disk and parse it to retrieve the
+    # unserialized graph_def
+    with tf.gfile.GFile(frozen_graph_filename, "rb") as f:
+        graph_def = tf.GraphDef()
+        graph_def.ParseFromString(f.read())
+
+    # Then, we import the graph_def into a new Graph and returns it
+    with tf.Graph().as_default() as graph:
+        # The name var will prefix every op/nodes in your graph
+        # Since we load everything in a new graph, this is not needed
+        tf.import_graph_def(graph_def, name="")
+    return graph
+
 
 def main(argv=None):
-    if FLAGS.tiny:
-        model = yolo_v3_tiny.yolo_v3_tiny
-    else:
-        model = yolo_v3.yolo_v3
+
+    print("Loading frozen graph")
+    t0 = time.time()
+    frozenGraph = load_graph(FLAGS.frozen_model)
+    print("Loaded graph in {:.2f}s".format(time.time()-t0))
 
     img = Image.open(FLAGS.input_img)
     img_resized = img.resize(size=(FLAGS.size, FLAGS.size))
 
     classes = load_coco_names(FLAGS.class_names)
 
-    # placeholder for detector inputs
-    inputs = tf.placeholder(tf.float32, [1, FLAGS.size, FLAGS.size, 3])
+    with frozenGraph.as_default():
+        boxes = tf.get_default_graph().get_tensor_by_name("output_boxes:0")
+        inputs = tf.get_default_graph().get_tensor_by_name("inputs:0")
 
-    with tf.variable_scope('detector'):
-        detections = model(inputs, len(classes),
-                           data_format=FLAGS.data_format)
+    gpu_options = tf.GPUOptions(per_process_gpu_memory_fraction=FLAGS.gpu_memory_fraction)
+    tfSession = tf.Session(
+        graph=frozenGraph,
+        config=tf.ConfigProto(
+            gpu_options=gpu_options,
+            log_device_placement=False,
+        )
+    )
 
-    saver = tf.train.Saver(var_list=tf.global_variables(scope='detector'))
+    t0 = time.time()
 
-    boxes = detections_boxes(detections)
-
-    with tf.Session() as sess:
-        saver.restore(sess, FLAGS.ckpt_file)
-        print('Model restored.')
-
-        detected_boxes = sess.run(
-            boxes, feed_dict={inputs: [np.array(img_resized, dtype=np.float32)]})
+    detected_boxes = tfSession.run(boxes, feed_dict={inputs: [np.array(img_resized, dtype=np.float32)]})
 
     filtered_boxes = non_max_suppression(detected_boxes,
                                          confidence_threshold=FLAGS.conf_threshold,
                                          iou_threshold=FLAGS.iou_threshold)
+    print("Predictions found in {:.2f}s".format(time.time() - t0))
 
     draw_boxes(filtered_boxes, img, classes, (FLAGS.size, FLAGS.size))
 

--- a/demo.py
+++ b/demo.py
@@ -12,7 +12,7 @@ FLAGS = tf.app.flags.FLAGS
 
 tf.app.flags.DEFINE_string('input_img', '', 'Input image')
 tf.app.flags.DEFINE_string('output_img', '', 'Output image')
-
+tf.app.flags.DEFINE_string('class_names', 'coco.names', 'File with class names')
 tf.app.flags.DEFINE_string('frozen_model', 'frozen_darknet_yolov3_model.pb', 'Frozen tensorflow protobuf model')
 
 tf.app.flags.DEFINE_integer('size', 416, 'Image size')

--- a/utils.py
+++ b/utils.py
@@ -86,7 +86,7 @@ def detections_boxes(detections):
     y1 = center_y + h2
 
     boxes = tf.concat([x0, y0, x1, y1], axis=-1)
-    detections = tf.concat([boxes, attrs], axis=-1)
+    detections = tf.concat([boxes, attrs], axis=-1, name="output_boxes")
     return detections
 
 

--- a/utils.py
+++ b/utils.py
@@ -5,20 +5,17 @@ import tensorflow as tf
 from PIL import ImageDraw
 
 def load_graph(frozen_graph_filename):
-    # We load the protobuf file from the disk and parse it to retrieve the
-    # unserialized graph_def
+
     with tf.gfile.GFile(frozen_graph_filename, "rb") as f:
         graph_def = tf.GraphDef()
         graph_def.ParseFromString(f.read())
 
-    # Then, we import the graph_def into a new Graph and returns it
     with tf.Graph().as_default() as graph:
-        # The name var will prefix every op/nodes in your graph
-        # Since we load everything in a new graph, this is not needed
         tf.import_graph_def(graph_def, name="")
+
     return graph
 
-def freeze_graph(sess):
+def freeze_graph(sess, output_graph):
 
     output_node_names = [
         "output_boxes",
@@ -27,15 +24,15 @@ def freeze_graph(sess):
     output_node_names = ",".join(output_node_names)
 
     output_graph_def = tf.graph_util.convert_variables_to_constants(
-        sess,  # The session is used to retrieve the weights
-        tf.get_default_graph().as_graph_def(),  # The graph_def is used to retrieve the nodes
-        output_node_names.split(",")  # The output node names are used to select the useful nodes
+        sess,
+        tf.get_default_graph().as_graph_def(),
+        output_node_names.split(",")
     )
 
-    # Finally we serialize and dump the output graph to the filesystem
-    with tf.gfile.GFile(FLAGS.output_graph, "wb") as f:
+    with tf.gfile.GFile(output_graph, "wb") as f:
         f.write(output_graph_def.SerializeToString())
-    print("%d ops in the final graph." % len(output_graph_def.node))
+
+    print("{} ops written to {}.".format(len(output_graph_def.node), output_graph))
 
 def load_weights(var_list, weights_file):
     """


### PR DESCRIPTION
Hi, this is my first time submitting a proper pull request, so please let me know if anything goes against best practices.
I've been trying implement yolo-v3 in tensorflows C api, which required converting it into a protobuf format.
The convert_weights_pb.py freezes the weights to a protobuf graph. I've modified demo.py to also accept the frozen graph.