### PR TITLE
Add yolov3-spp support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ To run demo type this in the command line:
     1. Download binary file with desired weights: 
         1. Full weights: `wget https://pjreddie.com/media/files/yolov3.weights`
         1. Tiny weights: `wget https://pjreddie.com/media/files/yolov3-tiny.weights` 
+        1. SPP weights: `wget https://pjreddie.com/media/files/yolov3-spp.weights` 
     2. Run `python ./convert_weights.py` and `python ./convert_weights_pb.py`        
 3. Run `python ./demo.py --input_img <path-to-image> --output_img <name-of-output-image> --frozen_model <path-to-frozen-model>`
 
@@ -33,7 +34,9 @@ To run demo type this in the command line:
         1.  `NCHW` (gpu only) or `NHWC`
     4. `--tiny`
         1. Use yolov3-tiny
-    5. `--ckpt_file`
+    5. `--spp`
+        1. Use yolov3-spp
+    6. `--ckpt_file`
         1. Output checkpoint file
 2. convert_weights_pb.py:
     1. `--class_names`
@@ -44,7 +47,9 @@ To run demo type this in the command line:
         1.  `NCHW` (gpu only) or `NHWC`
     4. `--tiny`
         1. Use yolov3-tiny
-    5. `--output_graph`
+    5. `--spp`
+        1. Use yolov3-spp
+    6. `--output_graph`
         1. Location to write the output .pb graph to
 3. demo.py
     1. `--class_names`

--- a/convert_weights.py
+++ b/convert_weights.py
@@ -17,6 +17,8 @@ tf.app.flags.DEFINE_string(
     'data_format', 'NCHW', 'Data format: NCHW (gpu only) / NHWC')
 tf.app.flags.DEFINE_bool(
     'tiny', False, 'Use tiny version of YOLOv3')
+tf.app.flags.DEFINE_bool(
+    'spp', False, 'Use SPP version of YOLOv3')
 tf.app.flags.DEFINE_string(
     'ckpt_file', './saved_model/model.ckpt', 'Chceckpoint file')
 
@@ -24,6 +26,8 @@ tf.app.flags.DEFINE_string(
 def main(argv=None):
     if FLAGS.tiny:
         model = yolo_v3_tiny.yolo_v3_tiny
+    elif FLAGS.spp:
+        model = yolo_v3.yolo_v3_spp
     else:
         model = yolo_v3.yolo_v3
 

--- a/convert_weights_pb.py
+++ b/convert_weights_pb.py
@@ -21,6 +21,8 @@ tf.app.flags.DEFINE_string(
 
 tf.app.flags.DEFINE_bool(
     'tiny', False, 'Use tiny version of YOLOv3')
+tf.app.flags.DEFINE_bool(
+    'spp', False, 'Use SPP version of YOLOv3')
 tf.app.flags.DEFINE_integer(
     'size', 416, 'Image size')
 
@@ -29,6 +31,8 @@ tf.app.flags.DEFINE_integer(
 def main(argv=None):
     if FLAGS.tiny:
         model = yolo_v3_tiny.yolo_v3_tiny
+    elif FLAGS.spp:
+        model = yolo_v3.yolo_v3_spp
     else:
         model = yolo_v3.yolo_v3
 

--- a/demo.py
+++ b/demo.py
@@ -29,6 +29,8 @@ tf.app.flags.DEFINE_string(
     'frozen_model', '', 'Frozen tensorflow protobuf model')
 tf.app.flags.DEFINE_bool(
     'tiny', False, 'Use tiny version of YOLOv3')
+tf.app.flags.DEFINE_bool(
+    'spp', False, 'Use SPP version of YOLOv3')
 
 tf.app.flags.DEFINE_integer(
     'size', 416, 'Image size')
@@ -71,6 +73,8 @@ def main(argv=None):
     else:
         if FLAGS.tiny:
             model = yolo_v3_tiny.yolo_v3_tiny
+        elif FLAGS.spp:
+            model = yolo_v3.yolo_v3_spp
         else:
             model = yolo_v3.yolo_v3
 


### PR DESCRIPTION
The aim of this PR is to add yolov3-spp support. This PR contains the following modifications.

* Add --spp options to enable SPP block.
* Add SPP block in yolo_block

And you can use the following command to convert darknet yolov3-spp weights into tensorflow model.
```
$ python python ./convert_weights_pb.py --class_names coco.names --weights_file yolov3-spp.weights --spp
```