### PR TITLE
Added support for Tiny Yolo network with PRN

### DIFF
--- a/convert_weights_pb.py
+++ b/convert_weights_pb.py
@@ -23,6 +23,7 @@ tf.app.flags.DEFINE_bool(
     'tiny', False, 'Use tiny version of YOLOv3')
 tf.app.flags.DEFINE_bool(
     'spp', False, 'Use SPP version of YOLOv3')
+tf.app.flags.DEFINE_bool('prn', False, 'Use Tiny Yolo With PRN')
 tf.app.flags.DEFINE_integer(
     'size', 416, 'Image size')
 
@@ -33,6 +34,8 @@ def main(argv=None):
         model = yolo_v3_tiny.yolo_v3_tiny
     elif FLAGS.spp:
         model = yolo_v3.yolo_v3_spp
+    elif FLAGS.prn :
+        model = yolo_v3_tiny.yolo_v3_tinyPRN
     else:
         model = yolo_v3.yolo_v3
 

--- a/yolo_v3_tiny.py
+++ b/yolo_v3_tiny.py
@@ -14,7 +14,6 @@ _LEAKY_RELU = 0.1
 _ANCHORS = [(10, 14),  (23, 27),  (37, 58),
             (81, 82),  (135, 169),  (344, 319)]
 
-
 def yolo_v3_tiny(inputs, num_classes, is_training=False, data_format='NCHW', reuse=False):
     """
     Creates YOLO v3 tiny model.
@@ -95,6 +94,99 @@ def yolo_v3_tiny(inputs, num_classes, is_training=False, data_format='NCHW', reu
                         inputs, num_classes, _ANCHORS[0:3], img_size, data_format)
                     detect_2 = tf.identity(detect_2, name='detect_2')
 
+                    detections = tf.concat([detect_1, detect_2], axis=1)
+                    detections = tf.identity(detections, name='detections')
+                    return detections
+
+
+
+
+def yolo_v3_tinyPRN(inputs, num_classes, is_training=False, data_format='NCHW', reuse=False):
+    """
+    Creates YOLO v3 tiny model.
+
+    :param inputs: a 4-D tensor of size [batch_size, height, width, channels].
+        Dimension batch_size may be undefined. The channel order is RGB.
+    :param num_classes: number of predicted classes.
+    :param is_training: whether is training or not.
+    :param data_format: data format NCHW or NHWC.
+    :param reuse: whether or not the network and its variables should be reused.
+    :return:
+    """
+    # it will be needed later on
+    img_size = inputs.get_shape().as_list()[1:3]
+
+    # transpose the inputs to NCHW
+    if data_format == 'NCHW':
+        inputs = tf.transpose(inputs, [0, 3, 1, 2])
+
+    # normalize values to range [0..1]
+    inputs = inputs / 255.0
+
+    # set batch norm params
+    batch_norm_params = {
+        'decay': _BATCH_NORM_DECAY,
+        'epsilon': _BATCH_NORM_EPSILON,
+        'scale': True,
+        'is_training': is_training,
+        'fused': None,  # Use fused batch norm if possible.
+    }
+    # Set activation_fn and parameters for conv2d, batch_norm.
+    with slim.arg_scope([slim.conv2d, slim.batch_norm, _fixed_padding, slim.max_pool2d], data_format=data_format):
+        with slim.arg_scope([slim.conv2d, slim.batch_norm, _fixed_padding], reuse=reuse):
+            with slim.arg_scope([slim.conv2d],
+                                normalizer_fn=slim.batch_norm,
+                                normalizer_params=batch_norm_params,
+                                biases_initializer=None,
+                                activation_fn=lambda x: tf.nn.leaky_relu(x, alpha=_LEAKY_RELU)):
+
+                with tf.variable_scope('yolo-v3-tinyPRN'):
+                    for i in range(6):
+                        inputs = _conv2d_fixed_padding(
+                            inputs, 16 * pow(2, i), 3)
+
+                        if i == 4:
+                            route_1 = inputs
+                            shortcut8 =inputs
+
+                        if i == 5:
+                            shortcut10 = inputs
+                            inputs = slim.max_pool2d(
+                                inputs, [2, 2], stride=1, padding="SAME", scope='pool2')
+
+                        else:
+                            inputs = slim.max_pool2d(
+                                inputs, [2, 2], scope='pool2')
+
+
+                    inputs = _conv2d_fixed_padding(inputs, 512, 3)
+                    inputs = inputs + shortcut10
+                    inputs = tf.nn.leaky_relu(inputs, alpha=_LEAKY_RELU)
+                    inputs = _conv2d_fixed_padding(inputs, 256, 1)
+                    shortcut14 = inputs
+                    inputs = _conv2d_fixed_padding(inputs, 256, 3)
+                    route15 = inputs
+                    inputs  = inputs + shortcut14
+                    inputs = tf.nn.leaky_relu(inputs, alpha=_LEAKY_RELU)
+                    detect_1 = _detection_layer(
+                        inputs, num_classes, _ANCHORS[3:6], img_size, data_format)
+
+                    detect_1 = tf.identity(detect_1, name='detect_1')
+                    inputs = _conv2d_fixed_padding(route15, 128, 1)
+                    upsample_size = route_1.get_shape().as_list()
+                    inputs = _upsample(inputs, upsample_size, data_format)
+                    shortcut21 = inputs
+                    inputs = inputs + shortcut8[-1,:,:,0:128]
+                    inputs = tf.nn.leaky_relu(inputs, alpha=_LEAKY_RELU)
+                    inputs = _conv2d_fixed_padding(inputs, 128, 3)
+                    inputs = inputs + shortcut21
+                    inputs = tf.nn.leaky_relu(inputs, alpha=_LEAKY_RELU)
+                    inputs = inputs + shortcut8[-1,:,:,0:128]
+                    inputs = tf.nn.leaky_relu(inputs, alpha=_LEAKY_RELU)
+                    detect_2 = _detection_layer(
+                        inputs, num_classes, _ANCHORS[1:4], img_size, data_format)
+
+                    detect_2 = tf.identity(detect_2, name='detect_2')
                     detections = tf.concat([detect_1, detect_2], axis=1)
                     detections = tf.identity(detections, name='detections')
                     return detections


### PR DESCRIPTION
Added support for converting Tiny Yolo V3 model with PRN as described in https://github.com/WongKinYiu/PartialResidualNetworks. Model conversion can be done by invoking --prn flag. 