### PR TITLE
Fix a bug in non_max_supression

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -185,10 +185,8 @@ def non_max_suppression(predictions_with_boxes, confidence_threshold, iou_thresh
 
     result = {}
     for i, image_pred in enumerate(predictions):
-        shape = image_pred.shape
-        non_zero_idxs = np.nonzero(image_pred)
-        image_pred = image_pred[non_zero_idxs]
-        image_pred = image_pred.reshape(-1, shape[-1])
+        # Remove predictions if all the prediction vector is zero
+        image_pred = image_pred[np.any(image_pred, axis=-1)]
 
         bbox_attrs = image_pred[:, :5]
         classes = image_pred[:, 5:]


### PR DESCRIPTION
There was a bug in the way the all zero prediction was removed from the
image_prediction tensor

This solution is correct, much more simple and clear